### PR TITLE
fix seams on tile borders

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -314,6 +314,7 @@ def parse_layer_data(tilestache_config):
             suppress_simplification=layer.provider.suppress_simplification,
             transform_fn_names=layer.provider.transform_fn_names,
             sort_fn_name=layer.provider.sort_fn_name,
+            simplify_before_intersect=layer.provider.simplify_before_intersect
         )
         layer_data.append(layer_datum)
     return layer_data

--- a/tilequeue/transform.py
+++ b/tilequeue/transform.py
@@ -58,7 +58,7 @@ def transform_feature_layers_shape(feature_layers, format, scale,
         transform_fn = lambda shape: shape
 
     is_vtm_format = format == vtm_format
-    shape_bounds = geometry.box(
+    format_padded_bounds = geometry.box(
         *(padded_bounds if is_vtm_format else unpadded_bounds))
 
     transformed_feature_layers = []
@@ -80,7 +80,7 @@ def transform_feature_layers_shape(feature_layers, format, scale,
             simplify_before_intersect = feature_layer['name'] in ['water', 'earth']
 
             if should_simplify and simplify_before_intersect:
-                min_x, min_y, max_x, max_y = shape_bounds
+                min_x, min_y, max_x, max_y = format_padded_bounds
                 gutter_bbox_size = (max_x - min_x) * 0.1
                 gutter_bbox = geometry.box(
                     min_x - gutter_bbox_size,
@@ -93,17 +93,17 @@ def transform_feature_layers_shape(feature_layers, format, scale,
 
             if is_vtm_format:
                 if is_clipped:
-                    shape = shape.intersection(shape_bounds)
+                    shape = shape.intersection(format_padded_bounds)
             else:
                 # for non vtm formats, we need to explicitly check if
                 # the geometry intersects with the unpadded bounds
-                if not shape_bounds.intersects(shape):
+                if not format_padded_bounds.intersects(shape):
                     continue
                 # now we know that we should include the geometry, but
                 # if the geometry should be clipped, we'll clip to the
                 # unpadded bounds
                 if is_clipped:
-                    shape = shape.intersection(shape_bounds)
+                    shape = shape.intersection(format_padded_bounds)
 
             if should_simplify and not simplify_before_intersect:
                 shape = shape.simplify(tolerance, preserve_topology=True)

--- a/tilequeue/transform.py
+++ b/tilequeue/transform.py
@@ -69,6 +69,7 @@ def transform_feature_layers_shape(feature_layers, format, scale,
         layer_datum = feature_layer['layer_datum']
         is_clipped = layer_datum['is_clipped']
 
+        simplify_before_intersect = layer_datum['simplify_before_intersect']
         for shape, props, feature_id in features:
             # perform any simplification as necessary
             tolerance = tolerances[coord.zoom]
@@ -77,10 +78,8 @@ def transform_feature_layers_shape(feature_layers, format, scale,
             should_simplify = coord.zoom not in suppress_simplification and \
                 coord.zoom < simplify_until
 
-            simplify_before_intersect = feature_layer['name'] in ['water', 'earth']
-
             if should_simplify and simplify_before_intersect:
-                min_x, min_y, max_x, max_y = format_padded_bounds
+                min_x, min_y, max_x, max_y = format_padded_bounds.bounds
                 gutter_bbox_size = (max_x - min_x) * 0.1
                 gutter_bbox = geometry.box(
                     min_x - gutter_bbox_size,


### PR DESCRIPTION
This PR fixes seams on tile borders, and is analogous to [this TileStache PR](https://github.com/mapzen/TileStache/pull/34). Note that you'll need to run:

```
pip install --upgrade git+https://github.com/mapzen/TileStache@remove-tile-seams
```

in order to pull in the necessary changes concerning the TileStache config.

related PRs: mapzen/vector-datasource#104, mapzen/TileStache#34