### PR TITLE
add option to seed custom bounding-boxes and filter metro-extracts

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -21,6 +21,11 @@ tiles:
       url: https://raw.githubusercontent.com/mapzen/metroextractor-cities/master/cities.json
       zoom-start: 11
       zoom-until: 15
+
+      # Can be set to an array of metro-extract city names, like
+      # 'new-york_new-york', to only seed tiles from those areas rather than
+      # all of them.
+      cities: Null
     top-tiles:
       url: https://gist.github.com/brunosan/b7ce3df8b48229a61b5b/raw/37e42e77f253bc204076111c92acc4d5e653edd2/top_50k_tiles.csv
       zoom-start: 11

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -25,7 +25,7 @@ tiles:
       # Can be set to an array of metro-extract city names, like
       # 'new-york_new-york', to only seed tiles from those areas rather than
       # all of them.
-      cities: Null
+      cities:
     top-tiles:
       url: https://gist.github.com/brunosan/b7ce3df8b48229a61b5b/raw/37e42e77f253bc204076111c92acc4d5e653edd2/top_50k_tiles.csv
       zoom-start: 11
@@ -38,7 +38,7 @@ tiles:
 
       # Must be set to an array of bounding boxes in `[left, bottom, right,
       # top]` (or `[min lon, min lat, max lon, max lat]`) format
-      bboxes: [[-74.501, 40.345, -73.226, 41.097]]
+      bboxes:
     should-add-to-tiles-of-interest: true
   intersect:
     expired-location: <path/to/expired/tiles/list>

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -30,6 +30,15 @@ tiles:
       url: https://gist.github.com/brunosan/b7ce3df8b48229a61b5b/raw/37e42e77f253bc204076111c92acc4d5e653edd2/top_50k_tiles.csv
       zoom-start: 11
       zoom-until: 20
+
+    # Specify any number of custom bounding boxes to seed tiles for.
+    custom:
+      zoom-start: 10
+      zoom-until: 10
+
+      # Must be set to an array of bounding boxes in `[left, bottom, right,
+      # top]` (or `[min lon, min lat, max lon, max lat]`) format
+      bboxes: [[-74.501, 40.345, -73.226, 41.097]]
     should-add-to-tiles-of-interest: true
   intersect:
     expired-location: <path/to/expired/tiles/list>

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -157,7 +157,12 @@ def make_seed_tile_generator(cfg):
     else:
         top_tiles = ()
 
-    combined_tiles = chain(all_tiles, metro_extract_tiles, top_tiles)
+    custom_tiles = tile_generator_for_multiple_bounds(
+        cfg.seed_custom_bboxes, cfg.seed_custom_zoom_start,
+        cfg.seed_custom_zoom_until)
+
+    combined_tiles = chain(
+        all_tiles, metro_extract_tiles, top_tiles, custom_tiles)
     tile_generator = uniquify_generator(combined_tiles)
 
     return tile_generator

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -133,7 +133,14 @@ def make_seed_tile_generator(cfg):
         with closing(urlopen(cfg.seed_metro_extract_url)) as fp:
             # will raise a MetroExtractParseError on failure
             metro_extracts = parse_metro_extract(fp)
+
+        city_filter = cfg.seed_metro_extract_cities
+        if city_filter is not None:
+            metro_extracts = [
+                city for city in metro_extracts if city.city in city_filter]
+
         multiple_bounds = city_bounds(metro_extracts)
+
         metro_extract_tiles = tile_generator_for_multiple_bounds(
             multiple_bounds, cfg.seed_metro_extract_zoom_start,
             cfg.seed_metro_extract_zoom_until)

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -157,9 +157,14 @@ def make_seed_tile_generator(cfg):
     else:
         top_tiles = ()
 
-    custom_tiles = tile_generator_for_multiple_bounds(
-        cfg.seed_custom_bboxes, cfg.seed_custom_zoom_start,
-        cfg.seed_custom_zoom_until)
+    if cfg.seed_custom_bboxes:
+        assert cfg.seed_custom_zoom_start is not None
+        assert cfg.seed_custom_zoom_until is not None
+        custom_tiles = tile_generator_for_multiple_bounds(
+            cfg.seed_custom_bboxes, cfg.seed_custom_zoom_start,
+            cfg.seed_custom_zoom_until)
+    else:
+        custom_tiles = ()
 
     combined_tiles = chain(
         all_tiles, metro_extract_tiles, top_tiles, custom_tiles)

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -140,7 +140,6 @@ def make_seed_tile_generator(cfg):
                 city for city in metro_extracts if city.city in city_filter]
 
         multiple_bounds = city_bounds(metro_extracts)
-
         metro_extract_tiles = tile_generator_for_multiple_bounds(
             multiple_bounds, cfg.seed_metro_extract_zoom_start,
             cfg.seed_metro_extract_zoom_until)

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -42,6 +42,20 @@ class Configuration(object):
         self.seed_should_add_to_tiles_of_interest = \
             seed_cfg['should-add-to-tiles-of-interest']
 
+        seed_custom = seed_cfg['custom']
+        self.seed_custom_zoom_start = seed_custom['zoom-start']
+        self.seed_custom_zoom_until = seed_custom['zoom-until']
+        self.seed_custom_bboxes = seed_custom['bboxes']
+        for bbox in self.seed_custom_bboxes:
+            assert len(bbox) == 4, (
+                'Seed config: custom bbox {} does not have exactly '
+                'four elements!').format(bbox)
+            min_x, min_y, max_x, max_y = bbox
+            assert min_x < max_x, \
+                'Invalid bbox. {} not less than {}'.format(min_x, max_x)
+            assert min_y < max_y, \
+                'Invalid bbox. {} not less than {}'.format(min_y, max_y)
+
         intersect_cfg = self.yml['tiles']['intersect']
         self.intersect_expired_tiles_location = (
             intersect_cfg['expired-location'])
@@ -110,7 +124,12 @@ def default_yml_config():
                     'zoom-start': None,
                     'zoom-until': None,
                 },
-                'should-add-to-tiles-of-interest': True,
+                'custom': {
+                    'zoom-start': None,
+                    'zoom-until': None,
+                    'bboxes': []
+                },
+                'should-add-to-tiles-of-interest': True
             },
             'intersect': {
                 'expired-location': None,

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -46,15 +46,16 @@ class Configuration(object):
         self.seed_custom_zoom_start = seed_custom['zoom-start']
         self.seed_custom_zoom_until = seed_custom['zoom-until']
         self.seed_custom_bboxes = seed_custom['bboxes']
-        for bbox in self.seed_custom_bboxes:
-            assert len(bbox) == 4, (
-                'Seed config: custom bbox {} does not have exactly '
-                'four elements!').format(bbox)
-            min_x, min_y, max_x, max_y = bbox
-            assert min_x < max_x, \
-                'Invalid bbox. {} not less than {}'.format(min_x, max_x)
-            assert min_y < max_y, \
-                'Invalid bbox. {} not less than {}'.format(min_y, max_y)
+        if self.seed_custom_bboxes:
+            for bbox in self.seed_custom_bboxes:
+                assert len(bbox) == 4, (
+                    'Seed config: custom bbox {} does not have exactly '
+                    'four elements!').format(bbox)
+                min_x, min_y, max_x, max_y = bbox
+                assert min_x < max_x, \
+                    'Invalid bbox. {} not less than {}'.format(min_x, max_x)
+                assert min_y < max_y, \
+                    'Invalid bbox. {} not less than {}'.format(min_y, max_y)
 
         intersect_cfg = self.yml['tiles']['intersect']
         self.intersect_expired_tiles_location = (

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -32,6 +32,7 @@ class Configuration(object):
         self.seed_metro_extract_url = seed_metro_cfg['url']
         self.seed_metro_extract_zoom_start = seed_metro_cfg['zoom-start']
         self.seed_metro_extract_zoom_until = seed_metro_cfg['zoom-until']
+        self.seed_metro_extract_cities = seed_metro_cfg['cities']
 
         seed_top_tiles_cfg = seed_cfg['top-tiles']
         self.seed_top_tiles_url = seed_top_tiles_cfg['url']
@@ -102,6 +103,7 @@ def default_yml_config():
                     'url': None,
                     'zoom-start': None,
                     'zoom-until': None,
+                    'cities': None
                 },
                 'top-tiles': {
                     'url': None,


### PR DESCRIPTION
Increase seeding configurability by:
  * allowing users to filter metro-extracts by city name
  * adding the ability to specify any number of custom bounding boxes