### PR TITLE
Add framework to post-process layers

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -342,8 +342,10 @@ def parse_layer_data(query_cfg, template_path, reload_templates):
         from tilequeue.query import JinjaQueryGenerator
     all_layer_names = query_cfg['all']
     layers_config = query_cfg['layers']
+    post_process_config = query_cfg.get('post_process', dict())
     layer_data = []
     all_layer_data = []
+    post_process_data = []
 
     environment = Environment(loader=FileSystemLoader(template_path))
     environment.filters['geometry'] = jinja_filter_geometry
@@ -371,7 +373,13 @@ def parse_layer_data(query_cfg, template_path, reload_templates):
         layer_data.append(layer_datum)
         if layer_name in all_layer_names:
             all_layer_data.append(layer_datum)
-    return all_layer_data, layer_data
+
+    for fn_name, params in post_process_config.items():
+        post_process_data.append(dict(
+            fn_name=fn_name,
+            params=dict(params)))
+
+    return all_layer_data, layer_data, post_process_data
 
 
 def tilequeue_process(cfg, peripherals):
@@ -383,7 +391,7 @@ def tilequeue_process(cfg, peripherals):
 
     with open(cfg.query_cfg) as query_cfg_fp:
         query_cfg = yaml.load(query_cfg_fp)
-    all_layer_data, layer_data = parse_layer_data(
+    all_layer_data, layer_data, post_process_data = parse_layer_data(
         query_cfg, cfg.template_path, cfg.reload_templates)
 
     formats = lookup_formats(cfg.output_formats)
@@ -446,7 +454,8 @@ def tilequeue_process(cfg, peripherals):
         feature_fetcher, sqs_input_queue, sql_data_fetch_queue, io_pool,
         peripherals.redis_cache_index, logger)
 
-    data_processor = ProcessAndFormatData(formats, sql_data_fetch_queue,
+    data_processor = ProcessAndFormatData(post_process_data, formats,
+                                          sql_data_fetch_queue,
                                           processor_queue, logger)
 
     s3_storage = S3Storage(processor_queue, s3_store_queue, io_pool,

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -67,12 +67,13 @@ def _postprocess_data(feature_layers, post_process_data):
         params = step['params']
 
         layer = fn(feature_layers, **params)
-        for index, feature_layer in enumerate(feature_layers):
-            layer_datum = feature_layer['layer_datum']
-            layer_name = layer_datum['name']
-            if layer_name == layer['name']:
-                feature_layers[index] = layer
-                break
+        if layer is not None:
+            for index, feature_layer in enumerate(feature_layers):
+                layer_datum = feature_layer['layer_datum']
+                layer_name = layer_datum['name']
+                if layer_name == layer['name']:
+                    feature_layers[index] = layer
+                    break
 
     return feature_layers
 

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -61,6 +61,19 @@ def _preprocess_data(feature_layers, shape_padded_bounds):
 # of other layers (e.g: projecting attributes, deleting hidden
 # features, etc...)
 def _postprocess_data(feature_layers, post_process_data):
+
+    for step in post_process_data:
+        fn = loadClassPath(step['fn_name'])
+        params = step['params']
+
+        layer = fn(feature_layers, **params)
+        for index, feature_layer in enumerate(feature_layers):
+            layer_datum = feature_layer['layer_datum']
+            layer_name = layer_datum['name']
+            if layer_name == layer['name']:
+                feature_layers[index] = layer
+                break
+
     return feature_layers
 
 def _cut_coord(feature_layers, shape_padded_bounds):

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -55,6 +55,7 @@ def _preprocess_data(feature_layers, shape_padded_bounds):
 
     return preproc_feature_layers
 
+
 # post-process all the layers simulataneously, which allows new
 # layers to be created from processing existing ones (e.g: for
 # computed centroids) or modifying layers based on the contents
@@ -76,6 +77,7 @@ def _postprocess_data(feature_layers, post_process_data):
                     break
 
     return feature_layers
+
 
 def _cut_coord(feature_layers, shape_padded_bounds):
     cut_feature_layers = []
@@ -140,7 +142,8 @@ def _process_feature_layers(feature_layers, coord, post_process_data,
         processed_feature_layers.append(feature_layer)
 
     # post-process data here, before it gets formatted
-    processed_feature_layers = _postprocess_data(processed_feature_layers, post_process_data)
+    processed_feature_layers = _postprocess_data(
+        processed_feature_layers, post_process_data)
 
     # topojson formatter expects bounds to be in wgs84
     unpadded_bounds_merc = unpadded_bounds

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -182,6 +182,7 @@ class DataFetch(object):
                 metadata=metadata,
                 coord=coord,
                 feature_layers=fetch_data['feature_layers'],
+                post_process_data=fetch_data['post_process_data'],
                 unpadded_bounds=fetch_data['unpadded_bounds'],
                 padded_bounds=fetch_data['padded_bounds'],
                 cut_coords=cut_coords,
@@ -200,8 +201,9 @@ class ProcessAndFormatData(object):
 
     scale = 4096
 
-    def __init__(self, formats, input_queue, output_queue, logger):
+    def __init__(self, post_process_data, formats, input_queue, output_queue, logger):
         formats.sort(key=attrgetter('sort_key'))
+        self.post_process_data = post_process_data
         self.formats = formats
         self.input_queue = input_queue
         self.output_queue = output_queue
@@ -231,8 +233,9 @@ class ProcessAndFormatData(object):
 
             try:
                 formatted_tiles = process_coord(
-                    coord, feature_layers, self.formats,
-                    unpadded_bounds, padded_bounds, cut_coords)
+                    coord, feature_layers, self.post_process_data,
+                    self.formats, unpadded_bounds, padded_bounds,
+                    cut_coords)
             except:
                 stacktrace = format_stacktrace_one_line()
                 self.logger.error('Error processing: %s - %s' % (

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -201,7 +201,8 @@ class ProcessAndFormatData(object):
 
     scale = 4096
 
-    def __init__(self, post_process_data, formats, input_queue, output_queue, logger):
+    def __init__(self, post_process_data, formats, input_queue, \
+                 output_queue, logger):
         formats.sort(key=attrgetter('sort_key'))
         self.post_process_data = post_process_data
         self.formats = formats

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -201,7 +201,7 @@ class ProcessAndFormatData(object):
 
     scale = 4096
 
-    def __init__(self, post_process_data, formats, input_queue, \
+    def __init__(self, post_process_data, formats, input_queue,
                  output_queue, logger):
         formats.sort(key=attrgetter('sort_key'))
         self.post_process_data = post_process_data


### PR DESCRIPTION
This adds a post-processing step which comes after the functions for transforming and sorting the individual layers. The post-processing step has access to the whole tile, and so it can modify existing layers or create new layers based on existing layers. This allows us to "intercut" one layer with another, see https://github.com/mapzen/TileStache/pull/37, or create layers based purely on already-queried data (e.g: centroids).

Note: this is part of trying to solve https://github.com/mapzen/vector-datasource/issues/136.