### PR TITLE
Added bbox_intersection filter for Jinja.

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -11,6 +11,7 @@ from tilequeue.metro_extract import city_bounds
 from tilequeue.metro_extract import parse_metro_extract
 from tilequeue.query import DataFetcher
 from tilequeue.query import jinja_filter_bbox_filter
+from tilequeue.query import jinja_filter_bbox_intersection
 from tilequeue.query import jinja_filter_geometry
 from tilequeue.queue import make_sqs_queue
 from tilequeue.tile import coord_int_zoom_up
@@ -350,6 +351,7 @@ def parse_layer_data(query_cfg, template_path, reload_templates):
     environment = Environment(loader=FileSystemLoader(template_path))
     environment.filters['geometry'] = jinja_filter_geometry
     environment.filters['bbox_filter'] = jinja_filter_bbox_filter
+    environment.filters['bbox_intersection'] = jinja_filter_bbox_intersection
 
     for layer_name, layer_config in layers_config.items():
         template_name = layer_config['template']

--- a/tilequeue/query.py
+++ b/tilequeue/query.py
@@ -47,6 +47,15 @@ def jinja_filter_bbox_filter(bounds, geometry_col_name, srid=900913):
     return bbox_filter
 
 
+def jinja_filter_bbox_intersection(bounds, geometry_col_name, srid=900913):
+    min_point = 'ST_MakePoint(%.12f, %.12f)' % (bounds[0], bounds[1])
+    max_point = 'ST_MakePoint(%.12f, %.12f)' % (bounds[2], bounds[3])
+    bbox_no_srid = 'ST_MakeBox2D(%s, %s)' % (min_point, max_point)
+    bbox = 'ST_SetSrid(%s, %d)' % (bbox_no_srid, srid)
+    bbox_intersection = 'st_intersection(%s, %s)' % (geometry_col_name, bbox)
+    return bbox_intersection
+
+
 def build_feature_queries(bounds, layer_data, zoom):
     queries_to_execute = []
     for layer_datum in layer_data:


### PR DESCRIPTION
Added bbox_intersection filter for Jinja, which allows clipping to the query bounding box. Although doing an intersection operation in the database rather than on the client can take some time, it seems it's worthwhile in this case to avoid sending too much over the network.

Connects to mapzen/vector-datasource#302.

@rmarianski could you review, please?