### PR TITLE
Fall back to using the geometry position

### DIFF
--- a/tilequeue/wof.py
+++ b/tilequeue/wof.py
@@ -223,10 +223,6 @@ def create_neighbourhood_from_json(json_data, neighbourhood_meta):
             return failure('Missing lbl:latitude or lbl:longitude and ' +
                            'geom:latitude or geom:longitude')
 
-        else:
-            self.logger.warn('Missing lbl:latitude or lbl:longitude for %d' %
-                             wof_id)
-
     try:
         label_lat = float(label_lat)
         label_lng = float(label_lng)

--- a/tilequeue/wof.py
+++ b/tilequeue/wof.py
@@ -214,7 +214,18 @@ def create_neighbourhood_from_json(json_data, neighbourhood_meta):
     label_lat = props.get('lbl:latitude')
     label_lng = props.get('lbl:longitude')
     if label_lat is None or label_lng is None:
-        return failure('Missing lbl:latitude or lbl:longitude')
+        # first, try to fall back to geom:* when lbl:* is missing. we'd prefer
+        # to have lbl:*, but it's better to have _something_ than nothing.
+        label_lat = props.get('geom:latitude')
+        label_lng = props.get('geom:longitude')
+
+        if label_lat is None or label_lng is None:
+            return failure('Missing lbl:latitude or lbl:longitude and ' +
+                           'geom:latitude or geom:longitude')
+
+        else:
+            self.logger.warn('Missing lbl:latitude or lbl:longitude for %d' %
+                             wof_id)
 
     try:
         label_lat = float(label_lat)


### PR DESCRIPTION
When the label position is missing. This isn't ideal, but the geometry position will suffice until the record is fixed.

The previous code would error if the label position was missing and, while missing the label position isn't great, it can be recovered from. The error, on the other hand, causes alerts, which is a bit extreme.

@nvkelso could you review, please?