### PR TITLE
Be robust to HTTP errors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,5 +8,6 @@ dependencies:
 test:
   override:
     - pip install -U 'mock==1.2.0'
+    - pip install -U httptestserver
     - python setup.py test
     - find . -not -path '*/.eggs/*' -name '*.py' | xargs flake8

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(name='tilequeue',
       ],
       test_suite='tests',
       tests_require=[
-          'mock'
+          'mock',
+          'httptestserver'
       ],
       entry_points=dict(
           console_scripts=[

--- a/tests/test_wof_http.py
+++ b/tests/test_wof_http.py
@@ -26,7 +26,7 @@ class _NullWofModel(object):
     def sync_neighbourhoods(
             self, neighbourhoods_to_add, neighbourhoods_to_update,
             ids_to_remove):
-        self.added   = self.added   + len(neighbourhoods_to_add)
+        self.added = self.added + len(neighbourhoods_to_add)
         self.updated = self.updated + len(neighbourhoods_to_update)
         self.removed = self.removed + len(ids_to_remove)
 
@@ -53,7 +53,6 @@ class _WofErrorHandler(http.BaseHTTPRequestHandler):
         request_count = self.wof_ctx.request_counts.get(self.path, 0)
 
         if request_count < self.wof_ctx.failure_count:
-            print "ERROR because %r < %r" % (request_count, self.wof_ctx.failure_count)
             self.wof_ctx.request_counts[self.path] = request_count + 1
             self.send_response(self.wof_ctx.failure_code)
             self.end_headers()
@@ -75,8 +74,8 @@ class _NullRedisTOI(object):
         return []
 
 
-# guard function to run a test HTTP server on another thread and reap it when it
-# goes out of scope.
+# guard function to run a test HTTP server on another thread and reap it when
+# it goes out of scope.
 @contextlib.contextmanager
 def _test_http_server(handler):
     server = Server('127.0.0.1', 0, 'http', handler)
@@ -109,20 +108,34 @@ class TestWofHttp(unittest.TestCase):
         context = _WofHandlerContext(num_failures, {
             '/meta/neighbourhoods.csv': (
                 'text/plain; charset=utf-8',
-                "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes\n"
-                "\"0,0,0,0\",u,,00000000000000000000000000000000,,00000000000000000000000000000000,0,0,1,u,,0,0,0,Null Island,-1,1/1.geojson,neighbourhood,null,,"
+                "bbox,cessation,deprecated,file_hash,fullname,geom_hash,"
+                "geom_latitude,geom_longitude,id,inception,iso,lastmodified,"
+                "lbl_latitude,lbl_longitude,name,parent_id,path,placetype,"
+                "source,superseded_by,supersedes\n"
+                "\"0,0,0,0\",u,,00000000000000000000000000000000,,"
+                "00000000000000000000000000000000,0,0,1,u,,0,0,0,Null Island,"
+                "-1,1/1.geojson,neighbourhood,null,,\n"
             ),
             '/meta/microhoods.csv': (
                 'text/plain; charset=utf-8',
-                "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes"
+                "bbox,cessation,deprecated,file_hash,fullname,geom_hash,"
+                "geom_latitude,geom_longitude,id,inception,iso,lastmodified,"
+                "lbl_latitude,lbl_longitude,name,parent_id,path,placetype,"
+                "source,superseded_by,supersedes\n"
             ),
             '/meta/macrohoods.csv': (
                 'text/plain; charset=utf-8',
-                "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes"
+                "bbox,cessation,deprecated,file_hash,fullname,geom_hash,"
+                "geom_latitude,geom_longitude,id,inception,iso,lastmodified,"
+                "lbl_latitude,lbl_longitude,name,parent_id,path,placetype,"
+                "source,superseded_by,supersedes\n"
             ),
             '/data/1/1.geojson': (
                 'application/json; charset=utf-8',
-                '{"id":1,"type":"Feature","properties":{"wof:id":1,"wof:name":"Null Island","lbl:latitude":0.0,"lbl:longitude":0.0,"wof:placetype":"neighbourhood"},"geometry":{"coordinates":[0,0],"type":"Point"}}'
+                '{"id":1,"type":"Feature","properties":{"wof:id":1,' +
+                '"wof:name":"Null Island","lbl:latitude":0.0,' +
+                '"lbl:longitude":0.0,"wof:placetype":"neighbourhood"},' +
+                '"geometry":{"coordinates":[0,0],"type":"Point"}}'
             )
         }, failure_code)
 
@@ -165,15 +178,15 @@ class TestWofHttp(unittest.TestCase):
     def test_with_single_failure(self):
         self._simple_test(1, 502)
 
-    # however, if we try to fetch a URL and it's missing then that really should
-    # be an error - probably indicates that we're not using the right logic to
-    # form the URLs.
+    # however, if we try to fetch a URL and it's missing then that really
+    # should be an error - probably indicates that we're not using the right
+    # logic to form the URLs.
     def test_with_missing(self):
-        with self.assertRaises(AssertionError) as a:
+        with self.assertRaises(AssertionError):
             self._simple_test(1, 404)
 
     # if we try to fetch a URL and it's forbidden then that really should be an
     # error - probably indicates a configuration problem with WOF.
     def test_with_forbidden(self):
-        with self.assertRaises(AssertionError) as a:
+        with self.assertRaises(AssertionError):
             self._simple_test(1, 403)

--- a/tests/test_wof_http.py
+++ b/tests/test_wof_http.py
@@ -34,27 +34,35 @@ class _NullWofModel(object):
         pass
 
 
+class _WofHandlerContext(object):
+
+    def __init__(self, failure_count=0, content={}, failure_code=500):
+        self.request_counts = {}
+        self.failure_count = failure_count
+        self.content = content
+        self.failure_code = failure_code
+
+
 class _WofErrorHandler(http.BaseHTTPRequestHandler):
 
-    def __init__(self, failure_count=0, content={}, *args):
-        self.wof_request_counts = {}
-        self.wof_failure_count = failure_count
-        self.wof_content = content
+    def __init__(self, context, *args):
+        self.wof_ctx = context
         http.BaseHTTPRequestHandler.__init__(self, *args)
 
     def do_GET(self):
-        request_count = self.wof_request_counts.get(self.path, 0)
+        request_count = self.wof_ctx.request_counts.get(self.path, 0)
 
-        if request_count < self.wof_failure_count:
-            self.wof_request_counts[self.path] = request_count + 1
-            self.send_response(500)
+        if request_count < self.wof_ctx.failure_count:
+            print "ERROR because %r < %r" % (request_count, self.wof_ctx.failure_count)
+            self.wof_ctx.request_counts[self.path] = request_count + 1
+            self.send_response(self.wof_ctx.failure_code)
             self.end_headers()
             self.wfile.write("")
 
         else:
             self.send_response(200)
             content_type, content \
-                = self.wof_content.get(self.path, ('text/plain', ''))
+                = self.wof_ctx.content.get(self.path, ('text/plain', ''))
             self.send_header('Content-Type', content_type)
             self.end_headers()
             self.wfile.write(content)
@@ -97,27 +105,29 @@ class _SimpleLogger(object):
 
 class TestWofHttp(unittest.TestCase):
 
-    def test_without_failures(self):
+    def _simple_test(self, num_failures=0, failure_code=500, max_retries=3):
+        context = _WofHandlerContext(num_failures, {
+            '/meta/neighbourhoods.csv': (
+                'text/plain; charset=utf-8',
+                "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes\n"
+                "\"0,0,0,0\",u,,00000000000000000000000000000000,,00000000000000000000000000000000,0,0,1,u,,0,0,0,Null Island,-1,1/1.geojson,neighbourhood,null,,"
+            ),
+            '/meta/microhoods.csv': (
+                'text/plain; charset=utf-8',
+                "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes"
+            ),
+            '/meta/macrohoods.csv': (
+                'text/plain; charset=utf-8',
+                "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes"
+            ),
+            '/data/1/1.geojson': (
+                'application/json; charset=utf-8',
+                '{"id":1,"type":"Feature","properties":{"wof:id":1,"wof:name":"Null Island","lbl:latitude":0.0,"lbl:longitude":0.0,"wof:placetype":"neighbourhood"},"geometry":{"coordinates":[0,0],"type":"Point"}}'
+            )
+        }, failure_code)
+
         def handler(*args):
-            return _WofErrorHandler(0, {
-                '/meta/neighbourhoods.csv': (
-                    'text/plain; charset=utf-8',
-                    "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes\n"
-                    "\"0,0,0,0\",u,,00000000000000000000000000000000,,00000000000000000000000000000000,0,0,1,u,,0,0,0,Null Island,-1,1/1.geojson,neighbourhood,null,,"
-                ),
-                '/meta/microhoods.csv': (
-                    'text/plain; charset=utf-8',
-                    "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes"
-                ),
-                '/meta/macrohoods.csv': (
-                    'text/plain; charset=utf-8',
-                    "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes"
-                ),
-                '/data/1/1.geojson': (
-                    'application/json; charset=utf-8',
-                    '{"id":1,"type":"Feature","properties":{"wof:id":1,"wof:name":"Null Island","lbl:latitude":0.0,"lbl:longitude":0.0,"wof:placetype":"neighbourhood"},"geometry":{"coordinates":[0,0],"type":"Point"}}'
-                )
-            }, *args)
+            return _WofErrorHandler(context, *args)
 
         model = _NullWofModel()
 
@@ -127,7 +137,7 @@ class TestWofHttp(unittest.TestCase):
                 server.url('/meta/microhoods.csv'),
                 server.url('/meta/macrohoods.csv'),
                 server.url('/data'),
-                1)
+                1, max_retries)
             redis = _NullRedisTOI()
 
             def intersector(dummy1, dummy2, dummy3):
@@ -145,3 +155,25 @@ class TestWofHttp(unittest.TestCase):
         self.assertEqual(model.added, 1)
         self.assertEqual(model.updated, 0)
         self.assertEqual(model.removed, 0)
+
+    # if there are no failures, then the process should complete correctly.
+    def test_without_failures(self):
+        self._simple_test(0, 502)
+
+    # if there are fewer failures than the number of retries, then it should
+    # process without an error.
+    def test_with_single_failure(self):
+        self._simple_test(1, 502)
+
+    # however, if we try to fetch a URL and it's missing then that really should
+    # be an error - probably indicates that we're not using the right logic to
+    # form the URLs.
+    def test_with_missing(self):
+        with self.assertRaises(AssertionError) as a:
+            self._simple_test(1, 404)
+
+    # if we try to fetch a URL and it's forbidden then that really should be an
+    # error - probably indicates a configuration problem with WOF.
+    def test_with_forbidden(self):
+        with self.assertRaises(AssertionError) as a:
+            self._simple_test(1, 403)

--- a/tests/test_wof_http.py
+++ b/tests/test_wof_http.py
@@ -1,0 +1,147 @@
+import unittest
+try:
+    # Python 2.x
+    import BaseHTTPServer as http
+except ImportError:
+    # Python 3.x
+    from http import server as http
+import contextlib
+from httptestserver import Server
+from tilequeue.wof import make_wof_url_neighbourhood_fetcher, \
+    WofProcessor
+
+
+# a mock wof model which does nothing - these tests are about
+# fetching the data, not parsing it.
+class _NullWofModel(object):
+
+    def __init__(self):
+        self.added = 0
+        self.updated = 0
+        self.removed = 0
+
+    def find_previous_neighbourhood_meta(self):
+        return []
+
+    def sync_neighbourhoods(
+            self, neighbourhoods_to_add, neighbourhoods_to_update,
+            ids_to_remove):
+        self.added   = self.added   + len(neighbourhoods_to_add)
+        self.updated = self.updated + len(neighbourhoods_to_update)
+        self.removed = self.removed + len(ids_to_remove)
+
+    def insert_neighbourhoods(self, neighbourhoods):
+        pass
+
+
+class _WofErrorHandler(http.BaseHTTPRequestHandler):
+
+    def __init__(self, failure_count=0, content={}, *args):
+        self.wof_request_counts = {}
+        self.wof_failure_count = failure_count
+        self.wof_content = content
+        http.BaseHTTPRequestHandler.__init__(self, *args)
+
+    def do_GET(self):
+        request_count = self.wof_request_counts.get(self.path, 0)
+
+        if request_count < self.wof_failure_count:
+            self.wof_request_counts[self.path] = request_count + 1
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write("")
+
+        else:
+            self.send_response(200)
+            content_type, content \
+                = self.wof_content.get(self.path, ('text/plain', ''))
+            self.send_header('Content-Type', content_type)
+            self.end_headers()
+            self.wfile.write(content)
+
+
+# fake Redis object to keep the code happy
+class _NullRedisTOI(object):
+
+    def fetch_tiles_of_interest(self):
+        return []
+
+
+# guard function to run a test HTTP server on another thread and reap it when it
+# goes out of scope.
+@contextlib.contextmanager
+def _test_http_server(handler):
+    server = Server('127.0.0.1', 0, 'http', handler)
+    server.start()
+    yield server
+
+
+# simple logger that's easy to turn the output on and off.
+class _SimpleLogger(object):
+
+    def __init__(self, verbose=True):
+        self.verbose = verbose
+
+    def info(self, msg):
+        if self.verbose:
+            print "INFO: %s" % msg
+
+    def warn(self, msg):
+        if self.verbose:
+            print "WARN: %s" % msg
+
+    def error(self, msg):
+        if self.verbose:
+            print "ERROR: %s" % msg
+
+
+class TestWofHttp(unittest.TestCase):
+
+    def test_without_failures(self):
+        def handler(*args):
+            return _WofErrorHandler(0, {
+                '/meta/neighbourhoods.csv': (
+                    'text/plain; charset=utf-8',
+                    "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes\n"
+                    "\"0,0,0,0\",u,,00000000000000000000000000000000,,00000000000000000000000000000000,0,0,1,u,,0,0,0,Null Island,-1,1/1.geojson,neighbourhood,null,,"
+                ),
+                '/meta/microhoods.csv': (
+                    'text/plain; charset=utf-8',
+                    "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes"
+                ),
+                '/meta/macrohoods.csv': (
+                    'text/plain; charset=utf-8',
+                    "bbox,cessation,deprecated,file_hash,fullname,geom_hash,geom_latitude,geom_longitude,id,inception,iso,lastmodified,lbl_latitude,lbl_longitude,name,parent_id,path,placetype,source,superseded_by,supersedes"
+                ),
+                '/data/1/1.geojson': (
+                    'application/json; charset=utf-8',
+                    '{"id":1,"type":"Feature","properties":{"wof:id":1,"wof:name":"Null Island","lbl:latitude":0.0,"lbl:longitude":0.0,"wof:placetype":"neighbourhood"},"geometry":{"coordinates":[0,0],"type":"Point"}}'
+                )
+            }, *args)
+
+        model = _NullWofModel()
+
+        with _test_http_server(handler) as server:
+            fetcher = make_wof_url_neighbourhood_fetcher(
+                server.url('/meta/neighbourhoods.csv'),
+                server.url('/meta/microhoods.csv'),
+                server.url('/meta/macrohoods.csv'),
+                server.url('/data'),
+                1)
+            redis = _NullRedisTOI()
+
+            def intersector(dummy1, dummy2, dummy3):
+                return []
+
+            def enqueuer(dummy):
+                pass
+
+            logger = _SimpleLogger(False)
+
+            processor = WofProcessor(fetcher, model, redis, intersector,
+                                     enqueuer, logger)
+            processor()
+
+        self.assertEqual(model.added, 1)
+        self.assertEqual(model.updated, 0)
+        self.assertEqual(model.removed, 0)

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -940,6 +940,7 @@ def tilequeue_process_wof_neighbourhoods(cfg, peripherals):
         wof_cfg['macrohoods-meta-url'],
         wof_cfg['data-prefix-url'],
         n_raw_neighbourhood_fetch_threads,
+        wof_cfg.get('max-retries', 0)
     )
     model = make_wof_model(wof_cfg['postgresql'])
 

--- a/tilequeue/wof.py
+++ b/tilequeue/wof.py
@@ -109,14 +109,14 @@ def _make_requests_session_with_retries(max_retries):
     a = HTTPAdapter(
         max_retries=Retry(
             total=max_retries,
-            status_forcelist=[ # this is a list of statuses to consider to be an
-                               # error and retry.
-                429, # Too many requests (i.e: back off)
-                500, # Generic internal server error
-                502, # Bad Gateway - i.e: upstream failure
-                503, # Unavailable, temporarily
-                504, # Gateway timeout
-                522  # Origin connection timed out
+            status_forcelist=[  # this is a list of statuses to consider to be
+                                # an error and retry.
+                429,  # Too many requests (i.e: back off)
+                500,  # Generic internal server error
+                502,  # Bad Gateway - i.e: upstream failure
+                503,  # Unavailable, temporarily
+                504,  # Gateway timeout
+                522   # Origin connection timed out
             ]
         ))
 

--- a/tilequeue/wof.py
+++ b/tilequeue/wof.py
@@ -117,7 +117,9 @@ def _make_requests_session_with_retries(max_retries):
                 503,  # Unavailable, temporarily
                 504,  # Gateway timeout
                 522   # Origin connection timed out
-            ]
+            ],
+            backoff_factor=1.0  # back off for 0s, 1s, 3s, 7s, etc... after
+                                # each successive failure. (factor*(2^N-1))
         ))
 
     # use retry for both HTTP and HTTPS connections.

--- a/tilequeue/wof.py
+++ b/tilequeue/wof.py
@@ -101,8 +101,35 @@ def parse_neighbourhood_meta_csv(csv_line_generator, placetype):
         yield neighbourhood_meta
 
 
-def fetch_wof_url_meta_neighbourhoods(url, placetype):
-    r = requests.get(url, stream=True)
+def _make_requests_session_with_retries(max_retries):
+    from requests.adapters import HTTPAdapter
+    from requests.packages.urllib3.util import Retry
+
+    s = requests.Session()
+    a = HTTPAdapter(
+        max_retries=Retry(
+            total=max_retries,
+            status_forcelist=[ # this is a list of statuses to consider to be an
+                               # error and retry.
+                429, # Too many requests (i.e: back off)
+                500, # Generic internal server error
+                502, # Bad Gateway - i.e: upstream failure
+                503, # Unavailable, temporarily
+                504, # Gateway timeout
+                522  # Origin connection timed out
+            ]
+        ))
+
+    # use retry for both HTTP and HTTPS connections.
+    s.mount('http://', a)
+    s.mount('https://', a)
+
+    return s
+
+
+def fetch_wof_url_meta_neighbourhoods(url, placetype, max_retries):
+    s = _make_requests_session_with_retries(max_retries)
+    r = s.get(url, stream=True)
     assert r.status_code == 200, 'Failure requesting: %s' % url
 
     csv_line_generator = generate_csv_lines(r)
@@ -277,9 +304,10 @@ def create_neighbourhood_from_json(json_data, neighbourhood_meta):
     return neighbourhood
 
 
-def fetch_url_raw_neighbourhood(url, neighbourhood_meta):
+def fetch_url_raw_neighbourhood(url, neighbourhood_meta, max_retries):
     try:
-        r = requests.get(url)
+        s = _make_requests_session_with_retries(max_retries)
+        r = s.get(url)
     except Exception, e:
         # if there is an IO error when fetching the url itself, we'll
         # want to halt too
@@ -335,12 +363,13 @@ def generate_wof_url(url_prefix, wof_id):
     return wof_url
 
 
-def make_fetch_raw_url_fn(data_url_prefix):
+def make_fetch_raw_url_fn(data_url_prefix, max_retries):
     def fn(neighbourhood_meta):
         wof_url = generate_wof_url(
             data_url_prefix, neighbourhood_meta.wof_id)
         neighbourhood = fetch_url_raw_neighbourhood(wof_url,
-                                                    neighbourhood_meta)
+                                                    neighbourhood_meta,
+                                                    max_retries)
         return neighbourhood
     return fn
 
@@ -417,27 +446,29 @@ def threaded_fetch(neighbourhood_metas, n_threads, fetch_raw_fn):
 class WofUrlNeighbourhoodFetcher(object):
 
     def __init__(self, neighbourhood_url, microhood_url, macrohood_url,
-                 data_url_prefix, n_threads):
+                 data_url_prefix, n_threads, max_retries):
         self.neighbourhood_url = neighbourhood_url
         self.microhood_url = microhood_url
         self.macrohood_url = macrohood_url
         self.data_url_prefix = data_url_prefix
         self.n_threads = n_threads
+        self.max_retries = max_retries
 
     def fetch_meta_neighbourhoods(self):
         return fetch_wof_url_meta_neighbourhoods(
-            self.neighbourhood_url, 'neighbourhood')
+            self.neighbourhood_url, 'neighbourhood', self.max_retries)
 
     def fetch_meta_microhoods(self):
         return fetch_wof_url_meta_neighbourhoods(
-            self.microhood_url, 'microhood')
+            self.microhood_url, 'microhood', self.max_retries)
 
     def fetch_meta_macrohoods(self):
         return fetch_wof_url_meta_neighbourhoods(
-            self.macrohood_url, 'macrohood')
+            self.macrohood_url, 'macrohood', self.max_retries)
 
     def fetch_raw_neighbourhoods(self, neighbourhood_metas):
-        url_fetch_fn = make_fetch_raw_url_fn(self.data_url_prefix)
+        url_fetch_fn = make_fetch_raw_url_fn(self.data_url_prefix,
+                                             self.max_retries)
         neighbourhoods, failures = threaded_fetch(
             neighbourhood_metas, self.n_threads, url_fetch_fn)
         return neighbourhoods, failures
@@ -1032,10 +1063,10 @@ class WofInitialLoader(object):
 
 def make_wof_url_neighbourhood_fetcher(
         neighbourhood_url, microhood_url, macrohood_url, data_prefix_url,
-        n_threads):
+        n_threads, max_retries):
     fetcher = WofUrlNeighbourhoodFetcher(
         neighbourhood_url, microhood_url, macrohood_url, data_prefix_url,
-        n_threads)
+        n_threads, max_retries)
     return fetcher
 
 

--- a/tilequeue/wof.py
+++ b/tilequeue/wof.py
@@ -844,6 +844,7 @@ class WofProcessor(object):
         else:
             self.logger.info('No raw neighbourhoods found to fetch')
             raw_neighbourhoods = ()
+            failures = []
 
         # we should just remove any neighbourhoods from add/update lists
         # also keep track of these ids to remove from the diffs too


### PR DESCRIPTION
Adds a configuration parameter for the number of retries to attempt when HTTP connections fail or return one of the whitelisted error status codes.

Connects to #60.

@nvkelso could you review, please?