### PR TITLE
Correct the s3 tile key path

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -69,4 +69,4 @@ class TestStoreKey(unittest.TestCase):
         layer = 'all'
         tile_key = s3_tile_key(date_str, path, layer, coord,
                                json_format.extension)
-        self.assertEqual(tile_key, '20160121/b707d/osm/all/8/72/105.json')
+        self.assertEqual(tile_key, '/20160121/b707d/osm/all/8/72/105.json')

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -55,3 +55,18 @@ class TestTileDirectory(unittest.TestCase):
                     'Tile data written to file does not match the input data')
 
             os.remove(expected_path)
+
+
+class TestStoreKey(unittest.TestCase):
+
+    def test_example_coord(self):
+        from tilequeue.store import s3_tile_key
+        from tilequeue.tile import deserialize_coord
+        from tilequeue.format import json_format
+        coord = deserialize_coord('8/72/105')
+        date_str = '20160121'
+        path = 'osm'
+        layer = 'all'
+        tile_key = s3_tile_key(date_str, path, layer, coord,
+                               json_format.extension)
+        self.assertEqual(tile_key, '20160121/b707d/osm/all/8/72/105.json')

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -23,7 +23,7 @@ def s3_tile_key(date, path, layer, coord, extension):
         ext=extension,
     )
     md5_hash = calc_hash(path_to_hash)
-    s3_path = '%(date)s/%(md5)s%(path_to_hash)s' % dict(
+    s3_path = '/%(date)s/%(md5)s%(path_to_hash)s' % dict(
         date=date,
         md5=md5_hash,
         path_to_hash=path_to_hash,

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -23,7 +23,7 @@ def s3_tile_key(date, path, layer, coord, extension):
         ext=extension,
     )
     md5_hash = calc_hash(path_to_hash)
-    s3_path = '%(date)s/%(md5)s/%(path_to_hash)s' % dict(
+    s3_path = '%(date)s/%(md5)s%(path_to_hash)s' % dict(
         date=date,
         md5=md5_hash,
         path_to_hash=path_to_hash,


### PR DESCRIPTION
This eliminates the extra slash from the s3 path. I don't think that this would make any difference, because it seems like the objects were still being saved in the correct location regardless. But this change probably makes sense to make anyway.

@zerebubuth could you review please?