### PR TITLE
Update json encoding to handle invalid geometries

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -39,7 +39,7 @@ class TestTileDirectory(unittest.TestCase):
         layer = 'all'
         for tile_data, (z, c, r), fmt in tiles_to_write:
             coords_obj = Coordinate(row=r, column=c, zoom=z)
-            format_obj = format.OutputFormat(fmt, fmt, None, None, None)
+            format_obj = format.OutputFormat(fmt, fmt, None, None, None, False)
             tile_dir.write_tile(tile_data, coords_obj, format_obj, layer)
 
             expected_filename = '{0}/{1}/{2}/{3}.{4}'.format(

--- a/tilequeue/format/__init__.py
+++ b/tilequeue/format/__init__.py
@@ -10,12 +10,14 @@ from TileStache.Goodies.VecTiles.topojson import merge as topojson_merge
 
 class OutputFormat(object):
 
-    def __init__(self, name, extension, mimetype, format_fn, sort_key):
+    def __init__(self, name, extension, mimetype, format_fn, sort_key,
+                 supports_shapely_geometry):
         self.name = name
         self.extension = extension
         self.mimetype = mimetype
         self.format_fn = format_fn
         self.sort_key = sort_key
+        self.supports_shapely_geometry = supports_shapely_geometry
 
     def __repr__(self):
         return 'OutputFormat(%s, %s, %s)' % \
@@ -78,13 +80,15 @@ def format_vtm(fp, feature_layers, coord, bounds_merc, bounds_wgs84):
     vtm_merge(fp, feature_layers, coord)
 
 
-json_format = OutputFormat('JSON', 'json', 'application/json', format_json, 1)
+json_format = OutputFormat('JSON', 'json', 'application/json', format_json, 1,
+                           True)
 topojson_format = OutputFormat('TopoJSON', 'topojson', 'application/json',
-                               format_topojson, 2)
+                               format_topojson, 2, False)
 # TODO image/png mimetype? app doesn't work unless image/png?
-vtm_format = OutputFormat('OpenScienceMap', 'vtm', 'image/png', format_vtm, 3)
+vtm_format = OutputFormat('OpenScienceMap', 'vtm', 'image/png', format_vtm, 3,
+                          False)
 mvt_format = OutputFormat('MVT', 'mvt', 'application/x-protobuf',
-                          format_mvt, 4)
+                          format_mvt, 4, True)
 
 extension_to_format = dict(
     json=json_format,

--- a/tilequeue/format/__init__.py
+++ b/tilequeue/format/__init__.py
@@ -1,7 +1,7 @@
 from cStringIO import StringIO
 from json import loads
-from TileStache.Goodies.VecTiles.geojson import encode as json_encode
-from TileStache.Goodies.VecTiles.geojson import merge as json_merge
+from tilequeue.format.geojson import encode_multiple_layers as json_encode_multiple_layers  # noqa
+from tilequeue.format.geojson import encode_single_layer as json_encode_single_layer  # noqa
 from TileStache.Goodies.VecTiles.mvt import merge as mvt_merge
 from TileStache.Goodies.VecTiles.oscimap import merge as vtm_merge
 from TileStache.Goodies.VecTiles.topojson import encode as topojson_encode
@@ -38,27 +38,21 @@ class OutputFormat(object):
 
 # consistent facade around all tilestache formatters that we use
 def format_json(fp, feature_layers, coord, bounds_merc, bounds_wgs84):
-    # TODO a lot of serializing/deserializing can be reduced here
-    # this is a faithful port for how it's done in tilestache now
     if len(feature_layers) == 1:
-        json_encode(fp, feature_layers[0]['features'], coord.zoom)
+        json_encode_single_layer(fp, feature_layers[0]['features'], coord.zoom)
         return
-    names = []
-    layers = []
-    for feature_layer in feature_layers:
-        names.append(feature_layer['name'])
-        out = StringIO()
-        json_encode(out, feature_layer['features'], coord.zoom)
-        # out now contains a json serialized result
-        # now we deserialize it, so that it can be combined with the
-        # merge function
-        deserialized_features = loads(out.getvalue())
-        layers.append(deserialized_features)
-    json_merge(fp, names, layers, None, coord)
+    else:
+        features_by_layer = {}
+        for feature_layer in feature_layers:
+            layer_name = feature_layer['name']
+            features = feature_layer['features']
+            features_by_layer[layer_name] = features
+        json_encode_multiple_layers(fp, features_by_layer, coord.zoom)
 
 
 def format_topojson(fp, feature_layers, coord, bounds_merc, bounds_wgs84):
-    # TODO ditto on the serialization as in format_json
+    # TODO a lot of serializing/deserializing can be reduced here
+    # this is a faithful port for how it's done in tilestache now
     if len(feature_layers) == 1:
         topojson_encode(fp, feature_layers[0]['features'], bounds_wgs84)
         return

--- a/tilequeue/format/geojson.py
+++ b/tilequeue/format/geojson.py
@@ -1,0 +1,79 @@
+from math import ceil
+from math import log
+import json
+import shapely.geometry
+import shapely.ops
+import shapely.wkb
+
+precisions = [int(ceil(log(1 << zoom + 8+2) / log(10)) - 2)
+              for zoom in range(17)]
+# at z16, need to be more precise for metatiling
+precisions[16] = 8
+
+
+class JsonFeatureCreator(object):
+
+    def __init__(self, precision=None):
+        self.precision = precision
+
+    def _trim_precision(self, x, y, z=None):
+        return round(x, self.precision), round(y, self.precision)
+
+    def __call__(self, feature):
+        assert len(feature) == 3
+        wkb_or_shape, props, fid = feature
+        if isinstance(wkb_or_shape, shapely.geometry.base.BaseGeometry):
+            shape = wkb_or_shape
+        else:
+            shape = shapely.wkb.loads(wkb_or_shape)
+
+        if self.precision:
+            truncated_precision_shape = shapely.ops.transform(
+                self._trim_precision, shape)
+            if truncated_precision_shape.is_valid:
+                shape = truncated_precision_shape
+
+        geometry = shape.__geo_interface__
+        result = dict(type='Feature', properties=props, geometry=geometry)
+        if fid is not None:
+            result['id'] = fid
+        return result
+
+
+def create_layer_feature_collection(features, precision):
+    create_json_feature = JsonFeatureCreator(precision)
+    fs = map(create_json_feature, features)
+    feature_collection = dict(type='FeatureCollection', features=fs)
+    return feature_collection
+
+
+def precision_for_zoom(zoom):
+    precision_idx = zoom if 0 <= zoom < len(precisions) else -1
+    precision = precisions[precision_idx]
+    return precision
+
+
+def encode_single_layer(out, features, zoom):
+    """
+    Encode a list of (WKB|shapely, property dict, id) features into a
+    GeoJSON stream.
+
+    If no id is available, pass in None
+
+    Geometries in the features list are assumed to be lon, lats.
+    """
+    precision = precision_for_zoom(zoom)
+    fs = create_layer_feature_collection(features, precision)
+    json.dump(fs, out)
+
+
+def encode_multiple_layers(out, features_by_layer, zoom):
+    """
+    features_by_layer should be a dict: layer_name -> feature tuples
+    """
+    precision = precision_for_zoom(zoom)
+    geojson = {}
+    for layer_name, features in features_by_layer.items():
+        fs = create_layer_feature_collection(features, precision)
+        geojson[layer_name] = fs
+    json.dump(geojson, out)

--- a/tilequeue/transform.py
+++ b/tilequeue/transform.py
@@ -104,10 +104,12 @@ def transform_feature_layers_shape(feature_layers, format, scale,
             # perform the format specific geometry transformations
             shape = transform_fn(shape)
 
-            # the formatters all expect wkb
-            wkb = dumps(shape)
+            if format.supports_shapely_geometry:
+                geom = shape
+            else:
+                geom = dumps(shape)
 
-            transformed_features.append((wkb, props, feature_id))
+            transformed_features.append((geom, props, feature_id))
 
         transformed_feature_layer = dict(
             name=feature_layer['name'],


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/698

Instead of using a custom json encoder to truncate precision, use the python `round` function.

I also added in other optimizations:

* avoid unnecessary serialization/deserialization to/from wkb for json and mvt.
* for json, instead of serializing and deserializing each layer and then serializing them all again, just make the appropriate structure and serialize once

@zerebubuth could you review please?