### PR TITLE
Add configurable buffer support

### DIFF
--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -6,7 +6,7 @@ class QueryBoundsTest(unittest.TestCase):
     def _call_fut(self, bounds, layer_name, buffer_cfg):
         from tilequeue.command import _create_query_bounds_pad_fn
         fn = _create_query_bounds_pad_fn(buffer_cfg, layer_name)
-        result = fn(bounds)
+        result = fn(bounds, 1)
         return result
 
     def test_no_bounds(self):

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,0 +1,225 @@
+import unittest
+
+
+class QueryBoundsTest(unittest.TestCase):
+
+    def _call_fut(self, bounds, layer_name, buffer_cfg):
+        from tilequeue.command import _create_query_bounds_pad_fn
+        fn = _create_query_bounds_pad_fn(buffer_cfg, layer_name)
+        result = fn(bounds)
+        return result
+
+    def test_no_bounds(self):
+        bounds = (0, 0, 1, 1)
+        result = self._call_fut(bounds, 'foo', {})
+        self.assertEquals(bounds, result)
+
+    def test_layer_not_configured(self):
+        bounds = (0, 0, 1, 1)
+        buffer_cfg = dict(foo={})
+        result = self._call_fut(bounds, 'baz', buffer_cfg)
+        self.assertEquals(bounds, result)
+
+    def test_layer_configured(self):
+        bounds = (1, 1, 2, 2)
+        buffer_cfg = {
+            'fmt': {
+                'layer': {
+                    'foo': {
+                        'point': 1
+                    }
+                }
+            }
+        }
+        result = self._call_fut(bounds, 'foo', buffer_cfg)
+        exp_bounds = (0, 0, 3, 3)
+        self.assertEquals(result, exp_bounds)
+
+    def test_geometry_configured(self):
+        bounds = (1, 1, 2, 2)
+        buffer_cfg = {
+            'fmt': {
+                'geometry': {
+                    'line': 1
+                }
+            }
+        }
+        result = self._call_fut(bounds, 'foo', buffer_cfg)
+        exp_bounds = (0, 0, 3, 3)
+        self.assertEquals(result, exp_bounds)
+
+    def test_layer_trumps_geometry(self):
+        bounds = (2, 2, 3, 3)
+        buffer_cfg = {
+            'fmt': {
+                'layer': {
+                    'foo': {
+                        'polygon': 2
+                    }
+                },
+                'geometry': {
+                    'line': 1
+                }
+            }
+        }
+        result = self._call_fut(bounds, 'foo', buffer_cfg)
+        exp_bounds = (0, 0, 5, 5)
+        self.assertEquals(result, exp_bounds)
+
+    def test_max_value_used(self):
+        bounds = (2, 2, 3, 3)
+        buffer_cfg = {
+            'fmt': {
+                'layer': {
+                    'foo': {
+                        'point': 1,
+                        'polygon': 2,
+                    }
+                }
+            }
+        }
+        result = self._call_fut(bounds, 'foo', buffer_cfg)
+        exp_bounds = (0, 0, 5, 5)
+        self.assertEquals(result, exp_bounds)
+
+
+class ClipBoundsTest(unittest.TestCase):
+
+    def _call_fut(
+            self, bounds, ext, layer_name, geometry_type, meters_per_pixel,
+            buffer_cfg):
+        from tilequeue.transform import calc_buffered_bounds
+        format = type(ext, (), dict(extension=ext))
+        result = calc_buffered_bounds(
+            format, bounds, meters_per_pixel, layer_name, geometry_type,
+            buffer_cfg)
+        return result
+
+    def test_empty(self):
+        bounds = (1, 1, 2, 2)
+        result = self._call_fut(bounds, 'foo', 'bar', 'point', 1, {})
+        self.assertEquals(result, bounds)
+
+    def test_diff_format(self):
+        bounds = (1, 1, 2, 2)
+        ext = 'quux'
+        result = self._call_fut(bounds, ext, 'bar', 'point', 1, dict(foo=42))
+        self.assertEquals(result, bounds)
+
+    def test_layer_match(self):
+        bounds = (1, 1, 2, 2)
+        ext = 'fmt'
+        layer_name = 'foo'
+        buffer_cfg = {
+            ext: {
+                'layer': {
+                    layer_name: {
+                        'line': 1
+                    }
+                }
+            }
+        }
+        result = self._call_fut(bounds, ext, layer_name, 'line', 1, buffer_cfg)
+        exp_bounds = (0, 0, 3, 3)
+        self.assertEquals(result, exp_bounds)
+
+    def test_geometry_match(self):
+        bounds = (1, 1, 2, 2)
+        ext = 'fmt'
+        layer_name = 'foo'
+        buffer_cfg = {
+            ext: {
+                'geometry': {
+                    'line': 1
+                }
+            }
+        }
+        result = self._call_fut(bounds, ext, layer_name, 'line', 1, buffer_cfg)
+        exp_bounds = (0, 0, 3, 3)
+        self.assertEquals(result, exp_bounds)
+
+    def test_layer_trumps_geometry(self):
+        bounds = (2, 2, 3, 3)
+        ext = 'fmt'
+        layer_name = 'foo'
+        buffer_cfg = {
+            ext: {
+                'layer': {
+                    layer_name: {
+                        'line': 2
+                    }
+                },
+                'geometry': {
+                    'line': 1
+                }
+            }
+        }
+        result = self._call_fut(bounds, ext, layer_name, 'line', 1, buffer_cfg)
+        exp_bounds = (0, 0, 5, 5)
+        self.assertEquals(result, exp_bounds)
+
+    def test_multiple_layer_geometry_types(self):
+        bounds = (2, 2, 3, 3)
+        ext = 'fmt'
+        layer_name = 'foo'
+        buffer_cfg = {
+            ext: {
+                'layer': {
+                    layer_name: {
+                        'point': 1,
+                        'line': 2,
+                        'polygon': 3,
+                    }
+                }
+            }
+        }
+        result = self._call_fut(bounds, ext, layer_name, 'line', 1, buffer_cfg)
+        exp_bounds = (0, 0, 5, 5)
+        self.assertEquals(result, exp_bounds)
+
+    def test_multi_geometry(self):
+        bounds = (1, 1, 2, 2)
+        ext = 'fmt'
+        layer_name = 'foo'
+        buffer_cfg = {
+            ext: {
+                'geometry': {
+                    'polygon': 1
+                }
+            }
+        }
+        result = self._call_fut(bounds, ext, layer_name, 'MultiPolygon', 1,
+                                buffer_cfg)
+        exp_bounds = (0, 0, 3, 3)
+        self.assertEquals(result, exp_bounds)
+
+    def test_geometry_no_match(self):
+        bounds = (1, 1, 2, 2)
+        ext = 'fmt'
+        layer_name = 'foo'
+        buffer_cfg = {
+            ext: {
+                'geometry': {
+                    'polygon': 1
+                }
+            }
+        }
+        result = self._call_fut(bounds, ext, layer_name, 'line', 1, buffer_cfg)
+        self.assertEquals(result, bounds)
+
+    def test_meters_per_pixel(self):
+        bounds = (2, 2, 3, 3)
+        ext = 'fmt'
+        layer_name = 'foo'
+        meters_per_pixel = 2
+        buffer_cfg = {
+            ext: {
+                'geometry': {
+                    'line': 1
+                }
+            }
+        }
+        result = self._call_fut(
+            bounds, ext, layer_name, 'line', meters_per_pixel, buffer_cfg)
+        exp_bounds = (0, 0, 5, 5)
+        self.assertEquals(result, exp_bounds)

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -14,6 +14,7 @@ from tilequeue.query import jinja_filter_bbox_intersection
 from tilequeue.query import jinja_filter_bbox
 from tilequeue.query import jinja_filter_geometry
 from tilequeue.queue import make_sqs_queue
+from tilequeue.tile import bounds_buffer
 from tilequeue.tile import coord_int_zoom_up
 from tilequeue.tile import coord_marshall_int
 from tilequeue.tile import coord_unmarshall_int
@@ -350,7 +351,7 @@ def _parse_postprocess_resources(post_process_item, cfg_path):
     return resources
 
 
-def _bounds_pad_no_buf(bounds):
+def _bounds_pad_no_buf(bounds, meters_per_pixel):
     return bounds
 
 
@@ -376,11 +377,11 @@ def _create_query_bounds_pad_fn(buffer_cfg, layer_name):
     if largest_buf == 0:
         return _bounds_pad_no_buf
 
-    def bounds_pad(bounds):
-        return (
-            bounds[0] - largest_buf, bounds[1] - largest_buf,
-            bounds[2] + largest_buf, bounds[3] + largest_buf,
-        )
+    def bounds_pad(bounds, meters_per_pixel):
+        offset = meters_per_pixel * largest_buf
+        result = bounds_buffer(bounds, offset)
+        return result
+
     return bounds_pad
 
 

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -80,6 +80,7 @@ class Configuration(object):
         self.template_path = process_cfg['template-path']
         self.reload_templates = process_cfg['reload-templates']
         self.output_formats = process_cfg['formats']
+        self.buffer_cfg = process_cfg['buffer']
 
         layers_to_format_cfg = process_cfg.get('layers-to-format')
         layers_to_format = []
@@ -171,6 +172,7 @@ def default_yml_config():
             'reload-templates': False,
             'formats': ['json'],
             'layers-to-format': [],
+            'buffer': {},
         },
         'logging': {
             'config': None

--- a/tilequeue/format/__init__.py
+++ b/tilequeue/format/__init__.py
@@ -93,12 +93,15 @@ vtm_format = OutputFormat('OpenScienceMap', 'vtm', 'image/png', format_vtm, 3,
                           False)
 mvt_format = OutputFormat('MVT', 'mvt', 'application/x-protobuf',
                           format_mvt, 4, True)
+# buffered mvt - same exact format as mvt, but has separate buffer config
+mvtb_format = mvt_format
 
 extension_to_format = dict(
     json=json_format,
     topojson=topojson_format,
     vtm=vtm_format,
     mvt=mvt_format,
+    mvtb=mvtb_format,
 )
 
 name_to_format = {

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -130,14 +130,14 @@ def _postprocess_data(
     return feature_layers
 
 
-def _cut_coord(feature_layers, unpadded_bounds, buffer_cfg):
+def _cut_coord(feature_layers, unpadded_bounds, meters_per_pixel, buffer_cfg):
     from tilequeue.command import _create_query_bounds_pad_fn
     cut_feature_layers = []
     for feature_layer in feature_layers:
         features = feature_layer['features']
         padded_bounds_fn = _create_query_bounds_pad_fn(
             buffer_cfg, feature_layer['name'])
-        padded_bounds = padded_bounds_fn(unpadded_bounds)
+        padded_bounds = padded_bounds_fn(unpadded_bounds, meters_per_pixel)
         shape_padded_bounds = geometry.box(*padded_bounds)
         cut_features = []
         for feature in features:
@@ -413,8 +413,10 @@ def process_coord(coord, feature_layers, post_process_data, formats,
         for cut_coord in cut_coords:
             unpadded_cut_bounds = coord_to_mercator_bounds(cut_coord)
 
+            meters_per_pixel = _find_meters_per_pixel(cut_coord.zoom)
             child_feature_layers = _cut_coord(
-                feature_layers, unpadded_cut_bounds, buffer_cfg)
+                feature_layers, unpadded_cut_bounds, meters_per_pixel,
+                buffer_cfg)
             child_formatted_tiles = _process_feature_layers(
                 child_feature_layers, cut_coord, post_process_data, formats,
                 unpadded_cut_bounds, scale, layers_to_format, buffer_cfg)

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -78,7 +78,9 @@ def _preprocess_data(feature_layers):
         preproc_feature_layer = dict(
             name=layer_datum['name'],
             layer_datum=layer_datum,
-            features=features)
+            features=features,
+            padded_bounds=padded_bounds,
+        )
         preproc_feature_layers.append(preproc_feature_layer)
 
     return preproc_feature_layers
@@ -153,7 +155,9 @@ def _cut_coord(feature_layers, unpadded_bounds, meters_per_pixel, buffer_cfg):
         cut_feature_layer = dict(
             name=feature_layer['name'],
             layer_datum=feature_layer['layer_datum'],
-            features=cut_features)
+            features=cut_features,
+            padded_bounds=padded_bounds,
+        )
         cut_feature_layers.append(cut_feature_layer)
 
     return cut_feature_layers
@@ -231,7 +235,7 @@ def _simplify_data(
 
         padded_bounds_fn = _create_query_bounds_pad_fn(
             buffer_cfg, feature_layer['name'])
-        padded_bounds = padded_bounds_fn(unpadded_bounds)
+        padded_bounds = padded_bounds_fn(unpadded_bounds, meters_per_pixel)
         layer_padded_bounds = \
             calculate_padded_bounds(clip_factor, padded_bounds)
         area_threshold_pixels = layer_datum['area_threshold']
@@ -292,6 +296,7 @@ def _simplify_data(
             name=feature_layer['name'],
             features=simplified_features,
             layer_datum=layer_datum,
+            padded_bounds=padded_bounds,
         )
         simplified_feature_layers.append(simplified_feature_layer)
 
@@ -352,8 +357,12 @@ def _process_feature_layers(
             sort_fn = resolve(sort_fn_name)
             processed_features = sort_fn(processed_features, coord.zoom)
 
-        feature_layer = dict(name=layer_name, features=processed_features,
-                             layer_datum=layer_datum)
+        feature_layer = dict(
+            name=layer_name,
+            features=processed_features,
+            layer_datum=layer_datum,
+            padded_bounds=feature_layer['padded_bounds'],
+        )
         processed_feature_layers.append(feature_layer)
 
     # post-process data here, before it gets formatted

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -4,7 +4,6 @@ from shapely.geometry import MultiPolygon
 from shapely import geometry
 from shapely.wkb import loads
 from tilequeue.tile import coord_to_mercator_bounds
-from tilequeue.tile import pad_bounds_for_zoom
 from tilequeue.tile import tolerance_for_zoom
 from tilequeue.transform import calculate_padded_bounds
 from tilequeue.transform import mercator_point_to_lnglat
@@ -29,12 +28,14 @@ def resolve_transform_fns(fn_dotted_names):
     return map(resolve, fn_dotted_names)
 
 
-def _preprocess_data(feature_layers, shape_padded_bounds):
+def _preprocess_data(feature_layers):
     preproc_feature_layers = []
 
     for feature_layer in feature_layers:
         layer_datum = feature_layer['layer_datum']
         geometry_types = layer_datum['geometry_types']
+        padded_bounds = feature_layer['padded_bounds']
+        shape_padded_bounds = geometry.box(*padded_bounds)
 
         features = []
         for row in feature_layer['features']:
@@ -89,7 +90,6 @@ Context = namedtuple('Context',
                      ['feature_layers',    # the feature layers list
                       'tile_coord',        # the original tile coordinate obj
                       'unpadded_bounds',   # the latlon bounds of the tile
-                      'padded_bounds',     # the padded bounds of the tile
                       'params',            # user configuration parameters
                       'resources'])        # resources declared in config
 
@@ -99,8 +99,8 @@ Context = namedtuple('Context',
 # computed centroids) or modifying layers based on the contents
 # of other layers (e.g: projecting attributes, deleting hidden
 # features, etc...)
-def _postprocess_data(feature_layers, post_process_data,
-                      tile_coord, unpadded_bounds, padded_bounds):
+def _postprocess_data(
+        feature_layers, post_process_data, tile_coord, unpadded_bounds):
 
     for step in post_process_data:
         fn = resolve(step['fn_name'])
@@ -109,7 +109,6 @@ def _postprocess_data(feature_layers, post_process_data,
             feature_layers=feature_layers,
             tile_coord=tile_coord,
             unpadded_bounds=unpadded_bounds,
-            padded_bounds=padded_bounds,
             params=step['params'],
             resources=step['resources'])
 
@@ -131,10 +130,15 @@ def _postprocess_data(feature_layers, post_process_data,
     return feature_layers
 
 
-def _cut_coord(feature_layers, shape_padded_bounds):
+def _cut_coord(feature_layers, unpadded_bounds, buffer_cfg):
+    from tilequeue.command import _create_query_bounds_pad_fn
     cut_feature_layers = []
     for feature_layer in feature_layers:
         features = feature_layer['features']
+        padded_bounds_fn = _create_query_bounds_pad_fn(
+            buffer_cfg, feature_layer['name'])
+        padded_bounds = padded_bounds_fn(unpadded_bounds)
+        shape_padded_bounds = geometry.box(*padded_bounds)
         cut_features = []
         for feature in features:
             shape, props, feature_id = feature
@@ -212,10 +216,10 @@ def _visible_shape(shape, area_threshold_meters):
         return shape
 
 
-def _simplify_data(feature_layers, bounds, zoom):
+def _simplify_data(
+        feature_layers, unpadded_bounds, zoom, meters_per_pixel, buffer_cfg):
+    from tilequeue.command import _create_query_bounds_pad_fn
     tolerance = tolerance_for_zoom(zoom)
-
-    meters_per_pixel = _find_meters_per_pixel(zoom)
 
     simplified_feature_layers = []
     for feature_layer in feature_layers:
@@ -224,8 +228,12 @@ def _simplify_data(feature_layers, bounds, zoom):
         layer_datum = feature_layer['layer_datum']
         is_clipped = layer_datum['is_clipped']
         clip_factor = layer_datum.get('clip_factor', 1.0)
+
+        padded_bounds_fn = _create_query_bounds_pad_fn(
+            buffer_cfg, feature_layer['name'])
+        padded_bounds = padded_bounds_fn(unpadded_bounds)
         layer_padded_bounds = \
-            calculate_padded_bounds(clip_factor, bounds)
+            calculate_padded_bounds(clip_factor, padded_bounds)
         area_threshold_pixels = layer_datum['area_threshold']
         area_threshold_meters = meters_per_pixel * area_threshold_pixels
 
@@ -291,12 +299,13 @@ def _simplify_data(feature_layers, bounds, zoom):
 
 
 def _create_formatted_tile(
-        feature_layers, format, scale, unpadded_bounds,
-        padded_bounds, unpadded_bounds_lnglat, coord, layer):
+        feature_layers, format, scale, unpadded_bounds, unpadded_bounds_lnglat,
+        coord, layer, meters_per_pixel, buffer_cfg):
+
     # perform format specific transformations
     transformed_feature_layers = transform_feature_layers_shape(
-        feature_layers, format, scale, unpadded_bounds,
-        padded_bounds, coord)
+        feature_layers, format, scale, unpadded_bounds, coord,
+        meters_per_pixel, buffer_cfg)
 
     # use the formatter to generate the tile
     tile_data_file = StringIO()
@@ -308,9 +317,10 @@ def _create_formatted_tile(
     return formatted_tile
 
 
-def _process_feature_layers(feature_layers, coord, post_process_data,
-                            formats, unpadded_bounds, padded_bounds,
-                            scale, layers_to_format):
+def _process_feature_layers(
+        feature_layers, coord, post_process_data, formats, unpadded_bounds,
+        scale, layers_to_format, buffer_cfg):
+
     processed_feature_layers = []
     # filter, and then transform each layer as necessary
     for feature_layer in feature_layers:
@@ -348,12 +358,14 @@ def _process_feature_layers(feature_layers, coord, post_process_data,
 
     # post-process data here, before it gets formatted
     processed_feature_layers = _postprocess_data(
-        processed_feature_layers, post_process_data, coord, unpadded_bounds,
-        padded_bounds)
+        processed_feature_layers, post_process_data, coord, unpadded_bounds)
+
+    meters_per_pixel = _find_meters_per_pixel(coord.zoom)
 
     # after post processing, perform simplification and clipping
     processed_feature_layers = _simplify_data(
-        processed_feature_layers, padded_bounds, coord.zoom)
+        processed_feature_layers, unpadded_bounds, coord.zoom,
+        meters_per_pixel, buffer_cfg)
 
     # topojson formatter expects bounds to be in lnglat
     unpadded_bounds_lnglat = (
@@ -367,7 +379,7 @@ def _process_feature_layers(feature_layers, coord, post_process_data,
     for format in formats:
         formatted_tile = _create_formatted_tile(
             processed_feature_layers, format, scale, unpadded_bounds,
-            padded_bounds, unpadded_bounds_lnglat, coord, layer)
+            unpadded_bounds_lnglat, coord, layer, meters_per_pixel, buffer_cfg)
         formatted_tiles.append(formatted_tile)
 
     # this assumes that we only store single layers, and no combinations
@@ -380,7 +392,8 @@ def _process_feature_layers(feature_layers, coord, post_process_data,
                 for format in formats:
                     formatted_tile = _create_formatted_tile(
                         pruned_feature_layers, format, scale, unpadded_bounds,
-                        padded_bounds, unpadded_bounds_lnglat, coord, layer)
+                        unpadded_bounds_lnglat, coord, layer, meters_per_pixel,
+                        buffer_cfg)
                     formatted_tiles.append(formatted_tile)
                     break
 
@@ -391,29 +404,24 @@ def _process_feature_layers(feature_layers, coord, post_process_data,
 # filter, transform, sort, post-process and then format according to
 # each formatter. this is the entry point from the worker process
 def process_coord(coord, feature_layers, post_process_data, formats,
-                  unpadded_bounds, padded_bounds, cut_coords, layers_to_format,
-                  scale=4096):
-    shape_padded_bounds = geometry.box(*padded_bounds)
-    feature_layers = _preprocess_data(feature_layers, shape_padded_bounds)
+                  unpadded_bounds, cut_coords, layers_to_format,
+                  buffer_cfg, scale=4096):
+    feature_layers = _preprocess_data(feature_layers)
 
     children_formatted_tiles = []
     if cut_coords:
         for cut_coord in cut_coords:
             unpadded_cut_bounds = coord_to_mercator_bounds(cut_coord)
-            padded_cut_bounds = pad_bounds_for_zoom(unpadded_cut_bounds,
-                                                    cut_coord.zoom)
 
-            shape_cut_padded_bounds = geometry.box(*padded_cut_bounds)
-            child_feature_layers = _cut_coord(feature_layers,
-                                              shape_cut_padded_bounds)
+            child_feature_layers = _cut_coord(
+                feature_layers, unpadded_cut_bounds, buffer_cfg)
             child_formatted_tiles = _process_feature_layers(
                 child_feature_layers, cut_coord, post_process_data, formats,
-                unpadded_cut_bounds, padded_cut_bounds, scale,
-                layers_to_format)
+                unpadded_cut_bounds, scale, layers_to_format, buffer_cfg)
             children_formatted_tiles.extend(child_formatted_tiles)
 
     coord_formatted_tiles = _process_feature_layers(
         feature_layers, coord, post_process_data, formats, unpadded_bounds,
-        padded_bounds, scale, layers_to_format)
+        scale, layers_to_format, buffer_cfg)
     all_formatted_tiles = coord_formatted_tiles + children_formatted_tiles
     return all_formatted_tiles

--- a/tilequeue/query.py
+++ b/tilequeue/query.py
@@ -67,10 +67,7 @@ def build_feature_queries(unpadded_bounds, layer_data, zoom):
     queries_to_execute = []
     for layer_datum in layer_data:
         query_bounds_pad_fn = layer_datum['query_bounds_pad_fn']
-        if query_bounds_pad_fn:
-            padded_bounds = query_bounds_pad_fn(unpadded_bounds)
-        else:
-            padded_bounds = unpadded_bounds
+        padded_bounds = query_bounds_pad_fn(unpadded_bounds)
         query_generator = layer_datum['query_generator']
         query = query_generator(padded_bounds, zoom)
         queries_to_execute.append((layer_datum, query, padded_bounds))

--- a/tilequeue/query.py
+++ b/tilequeue/query.py
@@ -1,5 +1,6 @@
 from psycopg2.extras import RealDictCursor
 from tilequeue.postgresql import DBAffinityConnectionsNoLimit
+from tilequeue.process import _find_meters_per_pixel
 from tilequeue.tile import coord_to_mercator_bounds
 import sys
 
@@ -64,10 +65,11 @@ def jinja_filter_bbox(bounds, srid=900913):
 
 
 def build_feature_queries(unpadded_bounds, layer_data, zoom):
+    meters_per_pixel = _find_meters_per_pixel(zoom)
     queries_to_execute = []
     for layer_datum in layer_data:
         query_bounds_pad_fn = layer_datum['query_bounds_pad_fn']
-        padded_bounds = query_bounds_pad_fn(unpadded_bounds)
+        padded_bounds = query_bounds_pad_fn(unpadded_bounds, meters_per_pixel)
         query_generator = layer_datum['query_generator']
         query = query_generator(padded_bounds, zoom)
         queries_to_execute.append((layer_datum, query, padded_bounds))

--- a/tilequeue/tile.py
+++ b/tilequeue/tile.py
@@ -303,12 +303,8 @@ def tolerance_for_zoom(zoom):
     return tolerance
 
 
-def pad_bounds_for_zoom(bounds, zoom):
-    minx, miny, maxx, maxy = bounds
-    tolerance = tolerance_for_zoom(zoom)
-    padding = 5 * tolerance
-    padded_bounds = (
-        minx - padding, miny - padding,
-        maxx + padding, maxy + padding,
+def bounds_buffer(bounds, buf_size):
+    return (
+        bounds[0] - buf_size, bounds[1] - buf_size,
+        bounds[2] + buf_size, bounds[3] + buf_size,
     )
-    return padded_bounds

--- a/tilequeue/transform.py
+++ b/tilequeue/transform.py
@@ -120,6 +120,9 @@ def transform_feature_layers_shape(
 
         for shape, props, feature_id in feature_layer['features']:
 
+            if shape.is_empty or shape.type == 'GeometryCollection':
+                continue
+
             buffer_padded_bounds = calc_buffered_bounds(
                 format, unpadded_bounds, meters_per_pixel, layer_name,
                 shape.type, buffer_cfg)

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -183,7 +183,6 @@ class DataFetch(object):
                 coord=coord,
                 feature_layers=fetch_data['feature_layers'],
                 unpadded_bounds=fetch_data['unpadded_bounds'],
-                padded_bounds=fetch_data['padded_bounds'],
                 cut_coords=cut_coords,
             )
 
@@ -201,13 +200,14 @@ class ProcessAndFormatData(object):
     scale = 4096
 
     def __init__(self, post_process_data, formats, input_queue,
-                 output_queue, layers_to_format, logger):
+                 output_queue, layers_to_format, buffer_cfg, logger):
         formats.sort(key=attrgetter('sort_key'))
         self.post_process_data = post_process_data
         self.formats = formats
         self.input_queue = input_queue
         self.output_queue = output_queue
         self.layers_to_format = layers_to_format
+        self.buffer_cfg = buffer_cfg
         self.logger = logger
 
     def __call__(self, stop):
@@ -226,7 +226,6 @@ class ProcessAndFormatData(object):
 
             coord = data['coord']
             feature_layers = data['feature_layers']
-            padded_bounds = data['padded_bounds']
             unpadded_bounds = data['unpadded_bounds']
             cut_coords = data['cut_coords']
 
@@ -235,8 +234,8 @@ class ProcessAndFormatData(object):
             try:
                 formatted_tiles = process_coord(
                     coord, feature_layers, self.post_process_data,
-                    self.formats, unpadded_bounds, padded_bounds,
-                    cut_coords, self.layers_to_format)
+                    self.formats, unpadded_bounds, cut_coords,
+                    self.layers_to_format, self.buffer_cfg)
             except:
                 stacktrace = format_stacktrace_one_line()
                 self.logger.error('Error processing: %s - %s' % (


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/106

The bounding box that the queries used is buffered to be the max of any of the buffer sizes configured across all formats. This trade-off allowed us to still use a single bounding box in the queries to keep things simpler for now. We could be more precise here, but we would need to update all queries to use the corresponding bounding box to match the geometry type.

Another potential performance issue is that the buffered bounds are calculated from the config per feature now, because the geometry type is a factor. This could be made faster if need be.

There are also some tileserver updates that are required. I'll put in a pr for that once the tilequeue changes are nailed down. There will also be updates necessary to the chef recipes that generate the config files.

Unfortunately, I also introduced some (more) circular imports, as well as importing some (more) functions that start with _ in other locations. I'd rather tackle this all at once separately since it was a problem before too.

@zerebubuth could you review please?