### PR TITLE
Discriminate query bounds on geometry type

### DIFF
--- a/tilequeue/tile.py
+++ b/tilequeue/tile.py
@@ -324,3 +324,20 @@ def calc_meters_per_pixel_area(zoom):
     meters_per_pixel_dim = calc_meters_per_pixel_dim(zoom)
     meters_per_pixel_area = meters_per_pixel_dim * meters_per_pixel_dim
     return meters_per_pixel_area
+
+
+_geom_type_lookup = {
+    'Point': 'point',
+    'MultiPoint': 'point',
+    'LineString': 'line',
+    'MultiLineString': 'line',
+    'Polygon': 'polygon',
+    'MultiPolygon': 'polygon',
+}
+
+
+def normalize_geometry_type(geom_type):
+    result = _geom_type_lookup.get(geom_type)
+    assert result, \
+        'normalize_geometry_type: unknown geometry %s' % geom_type
+    return result

--- a/tilequeue/transform.py
+++ b/tilequeue/transform.py
@@ -6,6 +6,7 @@ from tilequeue.format import json_format
 from tilequeue.format import topojson_format
 from tilequeue.format import vtm_format
 from tilequeue.tile import bounds_buffer
+from tilequeue.tile import normalize_geometry_type
 import math
 
 
@@ -73,9 +74,7 @@ def calc_buffered_bounds(
     if format_buffer_cfg is None:
         return bounds
 
-    if geometry_type.startswith('Multi'):
-        geometry_type = geometry_type[len('Multi'):]
-    geometry_type = geometry_type.lower()
+    geometry_type = normalize_geometry_type(geometry_type)
 
     per_layer_cfg = format_buffer_cfg.get('layer', {}).get(layer_name)
     if per_layer_cfg is not None:


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/106
Depends on https://github.com/mapzen/vector-datasource/pull/870

The query or `padded_bounds` are now a dict with 3 bounds keyed off of
geometry type.

@zerebubuth could you review please?